### PR TITLE
Fix various hard to read colors

### DIFF
--- a/hc-zenburn-theme.el
+++ b/hc-zenburn-theme.el
@@ -96,6 +96,7 @@ Also bind `class' to ((class color) (min-colors 89))."
 ;;;; Built-in
 ;;;;; basic coloring
    '(button ((t (:underline t))))
+   `(default ((t (:foreground ,hc-zenburn-fg :background ,hc-zenburn-bg))))
    `(link ((t (:foreground ,hc-zenburn-yellow :underline t :weight bold))))
    `(link-visited ((t (:foreground ,hc-zenburn-yellow-2 :underline t :weight normal))))
    `(default ((t (:foreground ,hc-zenburn-fg :background ,hc-zenburn-bg))))
@@ -129,6 +130,10 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(grep-hit-face ((t (:foreground ,hc-zenburn-blue))))
    `(grep-match-face ((t (:foreground ,hc-zenburn-orange :weight bold))))
    `(match ((t (:background ,hc-zenburn-bg-1 :foreground ,hc-zenburn-orange :weight bold))))
+;;;;; neotree
+   `(neo-file-link-face ((t (:background ,hc-zenburn-bg :foreground ,hc-zenburn-fg))))
+   `(neo-root-dir-face ((t (:foreground ,hc-zenburn-blue :weight bold))))
+   `(neo-dir-link-face ((t (:foreground ,hc-zenburn-green+1))))
 ;;;;; isearch
    `(isearch ((t (:foreground ,hc-zenburn-yellow-2 :weight bold :background ,hc-zenburn-bg+2))))
    `(isearch-fail ((t (:foreground ,hc-zenburn-fg :background ,hc-zenburn-red-4))))
@@ -218,14 +223,15 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(popup-isearch-match ((t (:background ,hc-zenburn-bg :foreground ,hc-zenburn-fg))))
 ;;;;; company-mode
    `(company-tooltip ((t (:foreground ,hc-zenburn-fg :background ,hc-zenburn-bg+1))))
+   `(company-tooltip-annotation ((t (:foreground ,hc-zenburn-orange :background ,hc-zenburn-bg+1))))
    `(company-tooltip-selection ((t (:foreground ,hc-zenburn-fg :background ,hc-zenburn-bg-1))))
    `(company-tooltip-mouse ((t (:background ,hc-zenburn-bg-1))))
    `(company-tooltip-common ((t (:foreground ,hc-zenburn-green+2))))
    `(company-tooltip-common-selection ((t (:foreground ,hc-zenburn-green+2))))
-   `(company-scrollbar-fg ((t (:background ,hc-zenburn-green+1))))
-   `(company-scrollbar-bg ((t (:background ,hc-zenburn-bg-1))))
-   `(company-preview ((t (:background ,hc-zenburn-green+1))))
-   `(company-preview-common ((t (:background ,hc-zenburn-bg-1))))
+   `(company-scrollbar-fg ((t (:background ,hc-zenburn-bg-1))))
+   `(company-scrollbar-bg ((t (:background ,hc-zenburn-bg+2))))
+   `(company-preview ((t (:background ,hc-zenburn-green+2))))
+   `(company-preview-common ((t (:foreground ,hc-zenburn-green+2 :background ,hc-zenburn-bg-1))))
 ;;;;; bm
    `(bm-face ((t (:background ,hc-zenburn-yellow-1 :foreground ,hc-zenburn-bg))))
    `(bm-fringe-face ((t (:background ,hc-zenburn-yellow-1 :foreground ,hc-zenburn-bg))))
@@ -610,6 +616,7 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(macrostep-macro-face
      ((t (:underline t))))
 ;;;;; magit
+   `(magit-blame-heading ((t (:background ,hc-zenburn-blue-3 :foreground ,hc-zenburn-bg))))
    `(magit-item-highlight ((t (:background ,hc-zenburn-bg+05))))
    `(magit-section-title ((t (:foreground ,hc-zenburn-yellow :weight bold))))
    `(magit-process-ok ((t (:foreground ,hc-zenburn-green :weight bold))))
@@ -977,7 +984,7 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(ansi-color-names-vector [,hc-zenburn-bg ,hc-zenburn-red ,hc-zenburn-green ,hc-zenburn-yellow
                                           ,hc-zenburn-blue ,hc-zenburn-magenta ,hc-zenburn-cyan ,hc-zenburn-fg])
 ;;;;; fill-column-indicator
-   `(fci-rule-color ,hc-zenburn-bg-05)
+   `(fci-rule-color ,hc-zenburn-bg+3)
 ;;;;; vc-annotate
    `(vc-annotate-color-map
      '(( 20. . ,hc-zenburn-red-1)


### PR DESCRIPTION
- Added `default` face for catch all
- Changed magit-blame-heading.  The original was very hard to see.
- Changed fci-rule-color.  Old one was very hard to read.
- Add neotree faces

I realize I'm getting into personal preference here, but, aside for the neotree updates, I've really just tried to change those things that were previously hard to read.  Such as `magit-blame-heading`, for example:

Before: http://d.pr/i/1kKYR/2hNI3PQe
After: http://d.pr/i/13OJl/4esOmxsd

In the case of NeoTree, I'm just setting it to use some of the zenburn colors instead of choosing it's own or using defaults.
