### PR TITLE
Make search highlighting more visible

### DIFF
--- a/hc-zenburn-theme.el
+++ b/hc-zenburn-theme.el
@@ -135,9 +135,9 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(neo-root-dir-face ((t (:foreground ,hc-zenburn-blue :weight bold))))
    `(neo-dir-link-face ((t (:foreground ,hc-zenburn-green+1))))
 ;;;;; isearch
-   `(isearch ((t (:foreground ,hc-zenburn-yellow-2 :weight bold :background ,hc-zenburn-bg+2))))
+   `(isearch ((t (:foreground ,hc-zenburn-bg :weight bold :background ,hc-zenburn-green+4))))
    `(isearch-fail ((t (:foreground ,hc-zenburn-fg :background ,hc-zenburn-red-4))))
-   `(lazy-highlight ((t (:foreground ,hc-zenburn-yellow-2 :weight bold :background ,hc-zenburn-bg-05))))
+   `(lazy-highlight ((t (:weight bold :background ,hc-zenburn-bg+3))))
 
    `(menu ((t (:foreground ,hc-zenburn-fg :background ,hc-zenburn-bg))))
    `(minibuffer-prompt ((t (:foreground ,hc-zenburn-yellow))))


### PR DESCRIPTION
The current search highlighting works in emacs lisp, because there aren't as many yellow keywords.  Have a look at this python code:

http://d.pr/i/1bGgw/2pQbvvpl

As you can see, there are already a LOT of yellow keywords.  Unfortunately, the lazy-highlight color as it is now is almost the same color.  It makes it hard to see previous searches.

This makes a big change from OG zenburn by putting the first match background as a green color, and then using a light background color for the persistent searches.

I'd post screenshots of those, but it turns out to be pretty hard to get a one before the search persist goes away.

Another thing I'd like to change, but I haven't figured out how:

When search persist stops, the search terms still remain "highlighted" with the regular "highlight" face.  I really like the current highlight face for selections, however, those search terms are hard to see.  The black background is hard to distinguish from the regular background when it doesn't extend past the term you were searching for. 
